### PR TITLE
Modified CSP for iOS

### DIFF
--- a/src/public/index.html.ejs
+++ b/src/public/index.html.ejs
@@ -4,7 +4,13 @@
   <!-- This file is the template for "www/index.html". Modify it to fit your needs -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-  <meta http-equiv="Content-Security-Policy" content="default-src * data: gap: https://ssl.gstatic.com; style-src * 'unsafe-inline'; worker-src * blob:; img-src * blob: data:; script-src * 'unsafe-inline' 'unsafe-eval'">
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src * data: gap: https://ssl.gstatic.com;
+    style-src * 'unsafe-inline';
+    img-src * blob: data:;
+    child-src * blob: gap:;
+    script-src * 'unsafe-inline' 'unsafe-eval'"
+  >
 
   <!-- The following EJS lines include the necessary CSS and JS
   from Monaca (cordova.js/ loader.js) in production mode -->


### PR DESCRIPTION
iOS has more strict CSP than Android and Chrome, so we had to add `child-src` directive, and remove `worker-src` directive that iOS and Safari cannot recognize.